### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Spiros Papadimitriou
 maintainer=Spiros Papadimitriou <spapadim@gmail.com>
 sentence=Arduino library for XPT2046 / ADS7843 touchscreen driver IC
 paragraph=Library for the ADS7843 touchscreen driver (and clones) that uses hardware SPI and differential mode.
+category=Display
 url=http://github.com/spapadim/XPT2046
 architectures=avr,esp8266


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library XPT2046 is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
