### PR TITLE
Fix overflow

### DIFF
--- a/XPT2046.h
+++ b/XPT2046.h
@@ -53,7 +53,7 @@ private:
   uint8_t _cs_pin, _irq_pin;
 
   int32_t _cal_dx, _cal_dy, _cal_dvi, _cal_dvj;
-  uint16_t _cal_vi1, _cal_vj1;
+  int32_t _cal_vi1, _cal_vj1;
 
   uint16_t _readLoop(uint8_t ctrl, uint8_t max_samples) const;
 };


### PR DESCRIPTION
I had a weird issue with my TJCTM24028-SPI (cheap eBay touch screen + TFT) and this library. When touching the lower 25% of the screen, the XPTPaint program worked ok, but when going into the top 75% the lines jumped off the screen and were not where my finger was touching. I tracked down the cause (or, at least, the change that fixes this) to the calibration variables `_cal_vi1` and `_cal_vj1`. These were previously set to `uint16_t`, but are used in a calibration operation involving `int32_t` numbers, potentially leading to overflow (as in my case). Changing these variables to `int32_t` fixes this overflow, and solves the problem on my screen with discontinuities.